### PR TITLE
[BOL-46] 파일 업로드 로직 구현 (#13)

### DIFF
--- a/app/src/main/java/com/yapp/bol/app/di/AppInterceptor.kt
+++ b/app/src/main/java/com/yapp/bol/app/di/AppInterceptor.kt
@@ -6,7 +6,6 @@ import okhttp3.Response
 class AppInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response = with(chain) {
         val newRequest = request().newBuilder()
-            .addHeader("Content-Type", "application/json")
             .build()
         proceed(newRequest)
     }

--- a/app/src/main/java/com/yapp/bol/app/di/DataSourceModule.kt
+++ b/app/src/main/java/com/yapp/bol/app/di/DataSourceModule.kt
@@ -3,6 +3,7 @@ package com.yapp.bol.app.di
 import com.yapp.bol.data.datasource.mock.MockDataSource
 import com.yapp.bol.data.datasource.mock.impl.MockDataSourceImpl
 import com.yapp.bol.data.remote.LoginApi
+import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -11,12 +12,9 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-class DataSourceModule {
-    @Provides
+interface DataSourceModule {
+
+    @Binds
     @Singleton
-    fun provideMockDataSource(
-        oauthApi: LoginApi
-    ): MockDataSource {
-        return MockDataSourceImpl(oauthApi)
-    }
+    fun bindsMockDataSource(mockDataSourceImpl: MockDataSourceImpl): MockDataSource
 }

--- a/app/src/main/java/com/yapp/bol/app/di/NetworkModule.kt
+++ b/app/src/main/java/com/yapp/bol/app/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.yapp.bol.app.di
 
 import com.yapp.bol.app.BuildConfig
+import com.yapp.bol.data.remote.ImageFileApi
 import com.yapp.bol.data.remote.LoginApi
 import com.yapp.bol.data.utils.Utils.BASE_URL
 import dagger.Module
@@ -11,6 +12,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.create
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -68,6 +70,13 @@ object NetworkModule {
     @Singleton
     fun provideOAuthApiService(retrofit: Retrofit): LoginApi {
         return retrofit.create(LoginApi::class.java)
+    }
+
+    @Provides
+
+    @Singleton
+    fun provideFileUploadApiService(retrofit: Retrofit): ImageFileApi {
+        return retrofit.create(ImageFileApi::class.java)
     }
 
     @Provides

--- a/buildSrc/src/main/java/com/yapp/bol/Dependencies.kt
+++ b/buildSrc/src/main/java/com/yapp/bol/Dependencies.kt
@@ -70,6 +70,11 @@ object OAuth {
     const val NAVER = "com.navercorp.nid:oauth:5.4.0"
 }
 
+object Glide {
+    const val GLIDE = "com.github.bumptech.glide:glide:4.13.0"
+    const val COMPILER = "com.github.bumptech.glide:compiler:4.13.0"
+}
+
 object Test {
     const val JUNIT = "junit:junit:4.13.2"
     const val TEST_RUNNER = "com.android.support.test:runner:1.0.2"

--- a/data/src/main/java/com/yapp/bol/data/datasource/MockDataSource.kt
+++ b/data/src/main/java/com/yapp/bol/data/datasource/MockDataSource.kt
@@ -1,0 +1,16 @@
+package com.yapp.bol.data.datasource
+
+import com.yapp.bol.data.model.MockApiResponse
+import com.yapp.bol.data.model.file_upload.FileUploadResponse
+import com.yapp.bol.domain.utils.RemoteErrorEmitter
+import java.io.File
+
+interface MockDataSource {
+    suspend fun getKakaoMock(remoteErrorEmitter: RemoteErrorEmitter, token: String): MockApiResponse?
+
+    suspend fun postFileUpload(
+        remoteErrorEmitter: RemoteErrorEmitter,
+        token: String,
+        file: File
+    ): FileUploadResponse?
+}

--- a/data/src/main/java/com/yapp/bol/data/datasource/impl/MockDataSourceImpl.kt
+++ b/data/src/main/java/com/yapp/bol/data/datasource/impl/MockDataSourceImpl.kt
@@ -1,0 +1,58 @@
+package com.yapp.bol.data.datasource.impl
+
+import com.yapp.bol.data.datasource.MockDataSource
+import com.yapp.bol.data.model.LoginType
+import com.yapp.bol.data.model.MockApiRequest
+import com.yapp.bol.data.model.MockApiResponse
+import com.yapp.bol.data.model.file_upload.FileUploadResponse
+import com.yapp.bol.data.utils.Image.GROUP_IMAGE
+import com.yapp.bol.data.remote.ImageFileApi
+import com.yapp.bol.data.remote.LoginApi
+import com.yapp.bol.data.utils.BaseRepository
+import com.yapp.bol.domain.utils.RemoteErrorEmitter
+import okhttp3.MediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import java.io.File
+import javax.inject.Inject
+
+
+class MockDataSourceImpl @Inject constructor(
+    private val oauthApi: LoginApi,
+    private val imageFileApi: ImageFileApi,
+) : BaseRepository(), MockDataSource {
+    override suspend fun getKakaoMock(remoteErrorEmitter: RemoteErrorEmitter, token: String): MockApiResponse? {
+        return safeApiCall(remoteErrorEmitter) {
+            oauthApi.postMockApi(MockApiRequest(LoginType.KAKAO_ACCESS_TOKEN, token)).body()
+        }
+    }
+
+    override suspend fun postFileUpload(
+        remoteErrorEmitter: RemoteErrorEmitter,
+        token: String,
+        file: File
+    ): FileUploadResponse? {
+
+        val fileBody = RequestBody.create(MediaType.parse(MEDIA_TYPE_IMAGE),file)
+        val filePart = MultipartBody.Part.createFormData(FILE_KEY,file.name,fileBody)
+        val purpose = RequestBody.create(MediaType.parse(MEDIA_TYPE_TEXT), GROUP_IMAGE)
+
+       return safeApiCall(remoteErrorEmitter) {
+           imageFileApi.postFileUpload(
+               token = token.convertRequestToken(),
+               file = filePart,
+               purpose = purpose
+           ).body()
+       }
+    }
+
+    private fun String.convertRequestToken(): String {
+        return "Bearer $this"
+    }
+
+    companion object {
+        const val MEDIA_TYPE_IMAGE = "image/*"
+        const val MEDIA_TYPE_TEXT = "text/*"
+        const val FILE_KEY = "file"
+    }
+}

--- a/data/src/main/java/com/yapp/bol/data/model/file_upload/FileUploadResponse.kt
+++ b/data/src/main/java/com/yapp/bol/data/model/file_upload/FileUploadResponse.kt
@@ -1,0 +1,5 @@
+package com.yapp.bol.data.model.file_upload
+
+data class FileUploadResponse(
+    val url: String
+)

--- a/data/src/main/java/com/yapp/bol/data/remote/ImageFileApi.kt
+++ b/data/src/main/java/com/yapp/bol/data/remote/ImageFileApi.kt
@@ -1,0 +1,21 @@
+package com.yapp.bol.data.remote
+
+import com.yapp.bol.data.model.file_upload.FileUploadResponse
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import retrofit2.Response
+import retrofit2.http.Header
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface ImageFileApi {
+
+    @Multipart
+    @POST("v1/file")
+    suspend fun postFileUpload(
+        @Header("Authorization") token: String,
+        @Part file: MultipartBody.Part,
+        @Part("purpose") purpose: RequestBody,
+    ): Response<FileUploadResponse>
+}

--- a/data/src/main/java/com/yapp/bol/data/repository/MockRepositoryImpl.kt
+++ b/data/src/main/java/com/yapp/bol/data/repository/MockRepositoryImpl.kt
@@ -5,15 +5,20 @@ import com.yapp.bol.data.mapper.MapperToDomain.toDomain
 import com.yapp.bol.domain.model.LoginItem
 import com.yapp.bol.domain.repository.MockRepository
 import com.yapp.bol.domain.utils.RemoteErrorEmitter
+import java.io.File
 import javax.inject.Inject
 
 class MockRepositoryImpl @Inject constructor(
     private val mockDataSource: MockDataSource,
 ) : MockRepository {
-
     override suspend fun login(
         emitter: RemoteErrorEmitter,
         type: String,
         token: String,
     ): LoginItem? = mockDataSource.login(emitter = emitter, type = type, token = token).toDomain()
+
+    override suspend fun postFileUpload(remoteErrorEmitter: RemoteErrorEmitter, token: String, file: File): String {
+        return mockDataSource.postFileUpload(remoteErrorEmitter,token,file)?.url ?: "Null !!!"
+    }
+
 }

--- a/data/src/main/java/com/yapp/bol/data/utils/Image.kt
+++ b/data/src/main/java/com/yapp/bol/data/utils/Image.kt
@@ -1,0 +1,6 @@
+package com.yapp.bol.data.utils
+
+object Image {
+    const val GROUP_IMAGE = "GROUP_IMAGE"
+    const val MATCH_IMAGE = "MATCH_IMAGE"
+}

--- a/domain/src/main/java/com/yapp/bol/domain/repository/MockRepository.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/repository/MockRepository.kt
@@ -2,7 +2,11 @@ package com.yapp.bol.domain.repository
 
 import com.yapp.bol.domain.model.LoginItem
 import com.yapp.bol.domain.utils.RemoteErrorEmitter
+import java.io.File
 
 interface MockRepository {
     suspend fun login(emitter: RemoteErrorEmitter, type: String, token: String): LoginItem?
+
+    suspend fun postFileUpload(remoteErrorEmitter: RemoteErrorEmitter, token: String, file: File): String
+
 }

--- a/domain/src/main/java/com/yapp/bol/domain/usecase/login/NewGroupUseCase.kt
+++ b/domain/src/main/java/com/yapp/bol/domain/usecase/login/NewGroupUseCase.kt
@@ -1,0 +1,14 @@
+package com.yapp.bol.domain.usecase.login
+
+import com.yapp.bol.domain.repository.MockRepository
+import com.yapp.bol.domain.utils.RemoteErrorEmitter
+import java.io.File
+import javax.inject.Inject
+
+class NewGroupUseCase @Inject constructor(
+    private val repository: MockRepository
+) {
+    suspend fun postFileUpload(remoteErrorEmitter: RemoteErrorEmitter, token: String, file: File): String {
+        return repository.postFileUpload(remoteErrorEmitter,token,file)
+    }
+}

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -89,6 +89,10 @@ dependencies {
     implementation(com.yapp.bol.OAuth.NAVER)
     implementation(com.yapp.bol.OAuth.KAKAO)
     implementation(com.yapp.bol.Firebase.GMS_AUTH)
+
+    // Glide
+    implementation(com.yapp.bol.Glide.GLIDE)
+    annotationProcessor(com.yapp.bol.Glide.COMPILER)
 }
 
 fun getProperty(propertyKey: String): String {

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application>
+        <activity
+            android:name=".view.login.NewGroupActivity"
+            android:exported="false" />
         <activity
             android:name=".view.login.GoogleTestActivity"
             android:exported="false">
@@ -22,9 +28,7 @@
             <meta-data
                 android:name="android.app.lib_name"
                 android:value="" />
-        </activity>
-
-        <!-- Kakao 로그인 -->
+        </activity> <!-- Kakao 로그인 -->
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true">

--- a/presentation/src/main/java/com/yapp/bol/presentation/utils/Constant.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/utils/Constant.kt
@@ -1,0 +1,5 @@
+package com.yapp.bol.presentation.utils
+
+object Constant {
+    const val EMPTY_STRING = ""
+}

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/login/KakaoTestActivity.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/login/KakaoTestActivity.kt
@@ -1,5 +1,6 @@
 package com.yapp.bol.presentation.view.login
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -12,6 +13,7 @@ import com.yapp.bol.presentation.BuildConfig
 import com.yapp.bol.presentation.databinding.ActivityKakaoTestBinding
 import com.yapp.bol.presentation.viewmodel.login.LoginType
 import com.yapp.bol.presentation.viewmodel.login.LoginViewModel
+import com.yapp.bol.presentation.utils.Constant.EMPTY_STRING
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -41,6 +43,13 @@ class KakaoTestActivity : AppCompatActivity() {
 
         KakaoSdk.init(this, KAKAO_API_KEY)
         kakaoLogin()
+
+        kakaoTestViewModel.accessToken.observe(this) {
+            if(it == EMPTY_STRING) return@observe
+            val intent = Intent(this, NewGroupActivity::class.java)
+            intent.putExtra(ACCESS_TOKEN,it)
+            startActivity(intent)
+        }
     }
 
     private fun kakaoLogin() {
@@ -56,10 +65,12 @@ class KakaoTestActivity : AppCompatActivity() {
             if (isClientErrorCancelled(error)) return@loginWithKakaoTalk
             error?.let { kakaoClient.loginWithKakaoAccount(this, callback = kakaoOAuthCallBack) }
             token?.let { viewModel.login(LoginType.KAKAO, token.accessToken) }
+
         }
     }
 
     companion object {
         const val KAKAO_API_KEY = BuildConfig.KAKAO_API_KEY
+        const val ACCESS_TOKEN = "Access Token"
     }
 }

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/login/NewGroupActivity.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/login/NewGroupActivity.kt
@@ -1,0 +1,115 @@
+package com.yapp.bol.presentation.view.login
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.database.Cursor
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.provider.MediaStore
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.bumptech.glide.Glide
+import com.yapp.bol.presentation.databinding.ActivityNewGroupBinding
+import com.yapp.bol.presentation.utils.Constant.EMPTY_STRING
+import com.yapp.bol.presentation.view.login.KakaoTestActivity.Companion.ACCESS_TOKEN
+import com.yapp.bol.presentation.viewmodel.NewGroupViewModel
+import dagger.hilt.android.AndroidEntryPoint
+import java.io.File
+
+@AndroidEntryPoint
+class NewGroupActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityNewGroupBinding
+    private val newGroupViewModel: NewGroupViewModel by viewModels()
+
+    private val isPermission: Boolean
+        get() = getPermission(WRITE_PERMISSION) != PackageManager.PERMISSION_DENIED
+            && getPermission(READ_PERMISSION) != PackageManager.PERMISSION_DENIED
+
+    private val imageResult= getResultLauncher()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityNewGroupBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val accessToken = intent.getStringExtra(ACCESS_TOKEN) ?: ""
+
+        binding.btnImage.setOnClickListener {
+            newGroupViewModel.postFileUpload(accessToken)
+        }
+
+        binding.ivImage.setOnClickListener {
+            checkedGalleryAccess()
+        }
+    }
+
+    private fun checkedGalleryAccess() {
+        if (isPermission)  generateGallery()
+        else ActivityCompat.requestPermissions(this, PERMISSIONS, REQ_GALLERY)
+    }
+
+    private fun generateGallery() {
+        val intent = Intent(Intent.ACTION_PICK).apply {
+            setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*")
+        }
+        imageResult.launch(intent)
+    }
+
+    private fun getPermission(permissionType: Int): Int {
+        return when (permissionType) {
+            WRITE_PERMISSION -> ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            READ_PERMISSION -> ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
+            else -> throw IllegalArgumentException("잘못된 권한 타입입니다.")
+        }
+    }
+
+    private fun getResultLauncher(): ActivityResultLauncher<Intent> {
+        return registerForActivityResult(
+            ActivityResultContracts.StartActivityForResult()
+        ) { result ->
+            if (result.resultCode != RESULT_OK) return@registerForActivityResult
+            val imageUri = result.data?.data ?: return@registerForActivityResult
+            val imageFile = File(getRealPathFromURI(imageUri))
+            newGroupViewModel.updateImageFile(imageFile)
+            setGroupImage(imageUri)
+        }
+    }
+
+    private fun getRealPathFromURI(uri: Uri): String {
+        val buildName = Build.MANUFACTURER
+        if (buildName == "Xiaomi") return uri.path ?: EMPTY_STRING
+
+        var columnIndex = 0
+        val cursor = getCursor(uri, arrayOf(MediaStore.Images.Media.DATA)) ?: return EMPTY_STRING
+        if (cursor.moveToFirst()) columnIndex = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATA)
+
+        val result = cursor.getString(columnIndex)
+        cursor.close()
+        return result
+    }
+
+    private fun setGroupImage(imageUri: Uri) {
+        Glide.with(this).load(imageUri).fitCenter().into(binding.ivImage)
+    }
+
+    private fun getCursor(uri: Uri, proj: Array<String>): Cursor? {
+        return contentResolver.query(uri, proj, null, null, null)
+    }
+
+    companion object {
+        const val REQ_GALLERY = 1
+        val PERMISSIONS = arrayOf(
+            Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        )
+        const val WRITE_PERMISSION = 1
+        const val READ_PERMISSION = 2
+    }
+}

--- a/presentation/src/main/java/com/yapp/bol/presentation/viewmodel/KakaoTestViewModel.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/viewmodel/KakaoTestViewModel.kt
@@ -1,0 +1,37 @@
+package com.yapp.bol.presentation.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yapp.bol.domain.model.MockApiItem
+import com.yapp.bol.domain.usecase.login.KakaoLoginUseCase
+import com.yapp.bol.domain.utils.ErrorType
+import com.yapp.bol.domain.utils.RemoteErrorEmitter
+import com.yapp.bol.presentation.utils.Constant.EMPTY_STRING
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+
+@HiltViewModel
+class KakaoTestViewModel @Inject constructor(
+    private val kakaoLoginUseCase: KakaoLoginUseCase,
+) : ViewModel(), RemoteErrorEmitter {
+
+    private val _accessToken = MutableLiveData(EMPTY_STRING)
+    val accessToken = _accessToken
+
+    fun loginTest(token: String) = viewModelScope.launch {
+        val response: MockApiItem? = kakaoLoginUseCase.execute(this@KakaoTestViewModel, token)
+        _accessToken.value = response?.accessToken ?: EMPTY_STRING
+    }
+
+    override fun onError(msg: String) {
+        Log.d("MOCK TEST", msg)
+    }
+
+    override fun onError(errorType: ErrorType) {
+        Log.d("MOCK TEST", errorType.name)
+    }
+}

--- a/presentation/src/main/java/com/yapp/bol/presentation/viewmodel/NewGroupViewModel.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/viewmodel/NewGroupViewModel.kt
@@ -1,0 +1,44 @@
+package com.yapp.bol.presentation.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.yapp.bol.domain.usecase.login.NewGroupUseCase
+import com.yapp.bol.domain.utils.ErrorType
+import com.yapp.bol.domain.utils.RemoteErrorEmitter
+import com.yapp.bol.presentation.utils.Constant.EMPTY_STRING
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import java.io.File
+import javax.inject.Inject
+
+@HiltViewModel
+class NewGroupViewModel @Inject constructor(
+    private val newGroupUseCase: NewGroupUseCase
+): ViewModel(), RemoteErrorEmitter {
+
+    private val _imageFile = MutableLiveData(File(EMPTY_STRING))
+    val imageFile = _imageFile
+
+    fun postFileUpload(token: String) {
+        viewModelScope.launch {
+            imageFile.value?.let {
+                newGroupUseCase.postFileUpload(this@NewGroupViewModel,token, it)
+            }
+        }
+    }
+
+    fun updateImageFile(file: File) {
+        _imageFile.value = file
+    }
+
+    override fun onError(msg: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun onError(errorType: ErrorType) {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/presentation/src/main/res/layout/activity_new_group.xml
+++ b/presentation/src/main/res/layout/activity_new_group.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".view.login.NewGroupActivity">
+
+    <ImageView
+        android:id="@+id/iv_image"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/btn_image"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btn_image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
* refactor: Interceptor  에 ContenetType 제거

* feat: 파일 업로드 Response 생성

* feat: ImageFileApi 생성

* feat: ImageFileApi 의존성 주입

* refactor: DataSourceModule Provide -> Binds

* feat: 파일 업로드 함수 구현 (DataSource)

* feat: 이미지 타입 생성

* feat: 피일 업로드 로직 구현 및 NewGroupUseCase 생성

* feat: NewGroupViewModel 생송

* feat: NewGroupActivity 생성

* feat: 로그인 화면에서 그룹 생성 화면 으로 토큰 값 보내기

* feat: kakaotestViewModel 생성

* feat: 읽기/쓰기 권한 추가

* feat: Glide 빌드 추가

* feat: 갤러리 접근 시 사용되는 데이터 상수화

* feat: getCursor 구현

* feat: setGroupImage 구현

* feat: getRealPathFromURI 구현 (진짜 파일로 만들어주는 함수)

* feat: getResultLauncher 구현

* feat: 권한 가져오기 & 체크 구현

* feat: generateGallery 함수 구현

* feat:checkedGalleryAccess 함수 구현

* feat: 버튼 클릭 시 갤러리 띄우기 & 파일 업로드 함수 호출

### Reference
- [Jira Ticket](https://yapp22-aos2.atlassian.net/browse/BOL-)

### 참고 사항

P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)
