### PR TITLE
[BOL-386]  매치 화면 멤버선택 진입 시 empty 화면 잠깐 보이는 버그 수정

### DIFF
--- a/presentation/src/main/java/com/yapp/bol/presentation/view/match/member_select/MemberSelectFragment.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/match/member_select/MemberSelectFragment.kt
@@ -147,7 +147,7 @@ class MemberSelectFragment : BaseFragment<FragmentMemberSelectBinding>(R.layout.
     }
 
     private fun setSearchResultNothing(visible: Boolean, keyword: String) = with(binding) {
-        if(keyword.isEmpty()) return@with
+        if (keyword.isEmpty()) return@with
         val searchResult = String.format(resources.getString(R.string.search_result_nothing), keyword)
         tvSearchResultNothing.apply {
             text = searchResult

--- a/presentation/src/main/java/com/yapp/bol/presentation/view/match/member_select/MemberSelectFragment.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/match/member_select/MemberSelectFragment.kt
@@ -147,15 +147,12 @@ class MemberSelectFragment : BaseFragment<FragmentMemberSelectBinding>(R.layout.
     }
 
     private fun setSearchResultNothing(visible: Boolean, keyword: String) = with(binding) {
+        if(keyword.isEmpty()) return@with
         val searchResult = String.format(resources.getString(R.string.search_result_nothing), keyword)
-        viewSearchResultNothing.isVisible = visible
-        tvSearchResultNothingGuide.isVisible = visible
-        btnGuestAddNothing.isVisible = visible
-        ivPlusNothing.isVisible = visible
         tvSearchResultNothing.apply {
             text = searchResult
-            isVisible = visible
         }
+        emptyGroup.isVisible = visible
     }
 
     private fun setPlayerRangeText(minPlayer: Int, maxPlayer: Int) {

--- a/presentation/src/main/res/layout/fragment_member_select.xml
+++ b/presentation/src/main/res/layout/fragment_member_select.xml
@@ -184,6 +184,13 @@
             app:layout_constraintStart_toEndOf="@+id/tv_guest_add_nothing"
             app:layout_constraintTop_toTopOf="@+id/btn_guest_add_nothing" />
 
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/empty_group"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:constraint_referenced_ids="tv_search_result_nothing,tv_search_result_nothing_guide,btn_guest_add_nothing,tv_guest_add_nothing,iv_plus_nothing" />
+
         <TextView
             android:id="@+id/btn_player_complete"
             android:layout_width="0dp"


### PR DESCRIPTION
### Reference
- [Jira Ticket](https://yapp22-aos2.atlassian.net/browse/BOL-386)

### 참고 사항

P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)
