### PR TITLE
[BOL-411] 멤버 검색 시 empty_string 검색 시 검색 경과 없음 가이드 노출 이슈 해결

### DIFF
--- a/presentation/src/main/java/com/yapp/bol/presentation/view/match/member_select/MemberSelectFragment.kt
+++ b/presentation/src/main/java/com/yapp/bol/presentation/view/match/member_select/MemberSelectFragment.kt
@@ -162,7 +162,6 @@ class MemberSelectFragment : BaseFragment<FragmentMemberSelectBinding>(R.layout.
     }
 
     private fun setSearchResultNothing(visible: Boolean, keyword: String) = with(binding) {
-        if (keyword.isEmpty()) return@with
         val searchResult = String.format(resources.getString(R.string.search_result_nothing), keyword)
         tvSearchResultNothing.apply {
             text = searchResult


### PR DESCRIPTION
### Reference
- [Jira Ticket](https://yapp22-aos2.atlassian.net/browse/BOL-411)

### 참고 사항

P1: 꼭 반영해주세요 (Request changes)
P2: 적극적으로 고려해주세요 (Request changes)
P3: 웬만하면 반영해 주세요 (Comment)
P4: 반영해도 좋고 넘어가도 좋습니다 (Approve)
P5: 그냥 사소한 의견입니다 (Approve)


<table>
<tr>
<td>수정 전</td>
<td>수정 후</td>
</tr>
<tr>
<td>





https://github.com/YAPP-Github/onboard-aos/assets/83493143/567072c8-8945-4c71-aa5e-90a4627224fa






</td>
<td>



https://github.com/YAPP-Github/onboard-aos/assets/83493143/ad2153bb-ecd4-44e8-9550-3cc013dcf97f






</td>
</tr>

